### PR TITLE
Fix SET_PROJECT call in updateProject

### DIFF
--- a/src/store/modules/projects.js
+++ b/src/store/modules/projects.js
@@ -82,7 +82,7 @@ export default {
 
       await updateProjectById(project)
       await dispatch('getProjects')
-      commit('SET_PROJECT', data)
+      commit('SET_PROJECT', project)
     },
     async setProject ({ commit, dispatch }, data) {
       dispatch('resetProject')


### PR DESCRIPTION
## Summary
- keep Vuex state up to date when updating a project

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a09dda364832a92eb409799b87c1d