### PR TITLE
Fix icon URL handling

### DIFF
--- a/src/components/templates/EmailTemplate1.vue
+++ b/src/components/templates/EmailTemplate1.vue
@@ -122,7 +122,7 @@
                             <a :href="formatLink(item.link)">
                               <img
                                 width="12px"
-                                :src="`${process.env.VUE_APP_API_URL}/icons/${item.icon}.png`"
+                                :src="iconUrl(`${item.icon}.png`)"
                                 :alt="`social-icon-${item.icon}`"
                                 style="display: table-cell; vertical-align: middle;"
                               >
@@ -195,12 +195,14 @@
 import EmailTemplate from './emailTemplate'
 import PromoteSignature from './components/PromoteSignature'
 import Avatar from './components/Avatar'
+import { iconUrl } from '../../util/icon'
 
 export default {
   components: {
     Avatar,
     PromoteSignature
   },
+  methods: { iconUrl },
   extends: EmailTemplate
 }
 </script>

--- a/src/components/templates/SignatureTemplate1.vue
+++ b/src/components/templates/SignatureTemplate1.vue
@@ -122,7 +122,7 @@
                             <a :href="formatLink(item.link)">
                               <img
                                 width="12px"
-                                :src="`${process.env.VUE_APP_API_URL}/icons/${item.icon}.png`"
+                                :src="iconUrl(`${item.icon}.png`)"
                                 :alt="`social-icon-${item.icon}`"
                                 style="display: table-cell; vertical-align: middle;"
                               >
@@ -228,6 +228,7 @@ import EmailTemplate from './emailTemplate'
 import Avatar from './components/Avatar'
 import PromoteSignature from './components/PromoteSignature'
 import BannerPlaceholder from './components/BannerPlaceholder'
+import { iconUrl } from '../../util/icon'
 
 export default {
   components: {
@@ -235,6 +236,7 @@ export default {
     PromoteSignature,
     BannerPlaceholder
   },
+  methods: { iconUrl },
   extends: EmailTemplate
 }
 </script>

--- a/src/components/templates/SignatureTemplate2.vue
+++ b/src/components/templates/SignatureTemplate2.vue
@@ -122,7 +122,7 @@
                             <a :href="formatLink(item.link)">
                               <img
                                 width="12px"
-                                :src="`${process.env.VUE_APP_API_URL}/icons/${item.icon}.png`"
+                                :src="iconUrl(`${item.icon}.png`)"
                                 :alt="`social-icon-${item.icon}`"
                                 style="display: table-cell; vertical-align: middle;"
                               >
@@ -231,6 +231,7 @@ import Avatar from './components/Avatar'
 import PromoteSignature from './components/PromoteSignature'
 import BannerPlaceholder from './components/BannerPlaceholder'
 import Divider from "./components/Divider"
+import { iconUrl } from '../../util/icon'
 
 export default {
   components: {
@@ -239,6 +240,7 @@ export default {
     BannerPlaceholder,
     Divider,
   },
+  methods: { iconUrl },
   extends: EmailTemplate
 }
 </script>

--- a/src/components/templates/SignatureTemplate3.vue
+++ b/src/components/templates/SignatureTemplate3.vue
@@ -113,7 +113,7 @@
                             <a :href="formatLink(item.link)">
                               <img
                                 width="12px"
-                                :src="`${process.env.VUE_APP_API_URL}/icons/${item.icon}.png`"
+                                :src="iconUrl(`${item.icon}.png`)"
                                 :alt="`social-icon-${item.icon}`"
                                 style="display: table-cell; vertical-align: middle;"
                               >
@@ -228,6 +228,7 @@ import EmailTemplate from './emailTemplate'
 import Avatar from './components/Avatar'
 import PromoteSignature from './components/PromoteSignature'
 import BannerPlaceholder from './components/BannerPlaceholder'
+import { iconUrl } from '../../util/icon'
 
 export default {
   components: {
@@ -235,6 +236,7 @@ export default {
     PromoteSignature,
     BannerPlaceholder
   },
+  methods: { iconUrl },
   extends: EmailTemplate
 }
 </script>

--- a/src/components/templates/SignatureTemplate4.vue
+++ b/src/components/templates/SignatureTemplate4.vue
@@ -122,7 +122,7 @@
                             <a :href="formatLink(item.link)">
                               <img
                                 width="12px"
-                                :src="`${process.env.VUE_APP_API_URL}/icons/${item.icon}.png`"
+                                :src="iconUrl(`${item.icon}.png`)"
                                 :alt="`social-icon-${item.icon}`"
                                 style="display: table-cell; vertical-align: middle;"
                               >
@@ -234,6 +234,7 @@ import PromoteSignature from './components/PromoteSignature'
 import BannerPlaceholder from './components/BannerPlaceholder'
 import Divider from "./components/Divider"
 import Tagline from "./components/Tagline"
+import { iconUrl } from '../../util/icon'
 
 export default {
   components: {
@@ -243,6 +244,7 @@ export default {
     Divider,
     Tagline,
   },
+  methods: { iconUrl },
   extends: EmailTemplate
 }
 </script>

--- a/src/store/modules/data.js
+++ b/src/store/modules/data.js
@@ -1,7 +1,4 @@
-const localIcon = name =>
-  process.env.VUE_APP_API_URL
-    ? `${process.env.VUE_APP_API_URL}/icons/${name}`
-    : require(`../../assets/image/${name}`)
+import { iconUrl } from '../../util/icon'
 
 export default {
   addons: {
@@ -9,11 +6,11 @@ export default {
     'This email and any files transmitted with it are confidential and intended solely for the use of the individual or entity to whom they are addressed. If you have received this email in error please notify the system manager. This message contains confidential information and is intended only for the individual named. If you are not the named addressee you should not disseminate, distribute or copy this e-mail. Please notify the sender immediately by e-mail if you have received this e-mail by mistake and delete this e-mail from your system. If you are not the intended recipient you are notified that disclosing, copying, distributing or taking any action in reliance on the contents of this information is strictly prohibited.',
     mobileApp: {
       appStore: {
-        img: localIcon('app-store-badge.png'),
+        img: iconUrl('app-store-badge.png'),
         link: 'http://example.com'
       },
       googlePlay: {
-        img: localIcon('google-play-badge.png'),
+        img: iconUrl('google-play-badge.png'),
         link: 'http://example.com'
       }
     }

--- a/src/util/icon.js
+++ b/src/util/icon.js
@@ -1,0 +1,4 @@
+export const iconUrl = name =>
+  process.env.VUE_APP_API_URL
+    ? `${process.env.VUE_APP_API_URL}/icons/${name}`
+    : `/icons/${name}`


### PR DESCRIPTION
## Summary
- add a small helper `iconUrl` to centralize icon URL generation
- use `iconUrl` for mobile app badges
- use `iconUrl` in all signature/email templates

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a188df8b0832a938f5f7092b1ceed