### PR TITLE
Add unified dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,24 +44,15 @@ Set env variables
 ```bash
 VUE_APP_API_URL=http://localhost:3000
 ```
-Run
+Install dependencies and start the development servers:
 
 ```bash
-npm i
-npm run serve
-```
-
-### Server
-
-The repository includes a small Express backend to handle file uploads.
-
-```bash
-cd server
 npm install
-npm start
+npm run dev
 ```
 
-The server listens on port `3001` by default and exposes `POST /api/upload`.
+The `dev` script starts the Vue application and the Express backend concurrently.
+The server listens on port `3001` and exposes `POST /api/upload`.
 Uploaded files are stored in `server/uploads/` and served statically, so they
 can be accessed from the Vue application via `/uploads/<filename>`.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "release": "sh ./build/bin/release.sh",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "dev": "concurrently \"npm run serve\" \"npm start --prefix server\""
   },
   "dependencies": {
     "chalk": "^2.4.2",
@@ -34,8 +35,10 @@
     "node-sass": "^4.11.0",
     "sass-loader": "^7.0.1",
     "vue-svg-loader": "^0.11.0",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "^2.5.17",
+    "concurrently": "^7.6.0"
   },
+  "postinstall": "npm install --prefix server",
   "gitHooks": {
     "pre-commit": "lint-staged",
     "commit-msg": "node scripts/verify-commit.js"


### PR DESCRIPTION
## Summary
- run server and client together with an npm `dev` script
- auto-install server deps via `postinstall`
- update documentation with streamlined instructions

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1cc6da18832abb6558ac02d4f797